### PR TITLE
Use AGPL license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Scanner
+Copyright (C) 2020 La France Insoumise
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Hello and thanks for your project!

Considering your intent to build numeric commons, and considering the online nature of the hosted service provided by scanner, I suggest with the current PR to place the project under the GNU AGPL license, a common choice for such cases.

If that option suits you, don't forget to make sure all copyright holders (such as coders and LFI) agree to the license change before merging the current PR :slightly_smiling_face: 